### PR TITLE
export getParliamentPoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as parliamentChart } from './src/parliament-chart';
+export { default as getParliamentPoints } from './chart-helpers';


### PR DESCRIPTION
because it's useful to get access to the positions, to render with something else than d3